### PR TITLE
Reproduce the ReferenceNotFoundException

### DIFF
--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -125,6 +125,17 @@ public class InterfaceBasedConverterCodecTests : FieldCodecTester<MyForeignLibra
     }
 
     protected override MyForeignLibraryInterface CreateValue() => new MyForeignLibraryType(12, "hi", DateTimeOffset.Now);
-    protected override bool Equals(MyForeignLibraryInterface left, MyForeignLibraryInterface right) => left.Equals(right);
+    protected override bool Equals(MyForeignLibraryInterface left, MyForeignLibraryInterface right) => ReferenceEquals(left, right) || left.Equals(right);
+    protected override MyForeignLibraryInterface[] TestValues => new MyForeignLibraryInterface[] { default, CreateValue() };
+}
+
+public class InterfaceBasedConverterCopierTests : CopierTester<MyForeignLibraryInterface, IDeepCopier<MyForeignLibraryInterface>>
+{
+    public InterfaceBasedConverterCopierTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override MyForeignLibraryInterface CreateValue() => new MyForeignLibraryType(12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(MyForeignLibraryInterface left, MyForeignLibraryInterface right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override MyForeignLibraryInterface[] TestValues => new MyForeignLibraryInterface[] { default, CreateValue() };
 }

--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -117,3 +117,14 @@ public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibr
     protected override bool Equals(DerivedFromMyForeignLibraryType left, DerivedFromMyForeignLibraryType right) => ReferenceEquals(left, right) || left.Equals(right);
     protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };
 }
+
+public class InterfaceBasedConverterCodecTests : FieldCodecTester<MyForeignLibraryInterface, IFieldCodec<MyForeignLibraryInterface>>
+{
+    public InterfaceBasedConverterCodecTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override MyForeignLibraryInterface CreateValue() => new MyForeignLibraryType(12, "hi", DateTimeOffset.Now);
+    protected override bool Equals(MyForeignLibraryInterface left, MyForeignLibraryInterface right) => left.Equals(right);
+    protected override MyForeignLibraryInterface[] TestValues => new MyForeignLibraryInterface[] { default, CreateValue() };
+}

--- a/test/Orleans.Serialization.UnitTests/Models.cs
+++ b/test/Orleans.Serialization.UnitTests/Models.cs
@@ -172,7 +172,14 @@ public class SomeClassWithSerializers
 
 namespace Orleans.Serialization.UnitTests
 {
-    public class MyForeignLibraryType
+    public interface MyForeignLibraryInterface
+    {
+        public int Num { get; set; }
+        public string String { get; set; }
+        public DateTimeOffset DateTimeOffset { get; set; }
+    }
+
+    public class MyForeignLibraryType : MyForeignLibraryInterface
     {
         public MyForeignLibraryType() { }
 
@@ -218,6 +225,23 @@ namespace Orleans.Serialization.UnitTests
         public MyForeignLibraryTypeSurrogate ConvertToSurrogate(in MyForeignLibraryType value)
             => new() { Num = value.Num, String = value.String, DateTimeOffset = value.DateTimeOffset };
         public void Populate(in MyForeignLibraryTypeSurrogate surrogate, MyForeignLibraryType value)
+        {
+            value.Num = surrogate.Num;
+            value.String = surrogate.String;
+            value.DateTimeOffset = surrogate.DateTimeOffset;
+        }
+    }
+
+    [RegisterConverter]
+    public sealed class MyForeignLibraryInterfaceSurrogateConverter : IConverter<MyForeignLibraryInterface, MyForeignLibraryTypeSurrogate>, IPopulator<MyForeignLibraryInterface, MyForeignLibraryTypeSurrogate>
+    {
+        public MyForeignLibraryInterface ConvertFromSurrogate(in MyForeignLibraryTypeSurrogate surrogate)
+            => new MyForeignLibraryType(surrogate.Num, surrogate.String, surrogate.DateTimeOffset);
+
+        public MyForeignLibraryTypeSurrogate ConvertToSurrogate(in MyForeignLibraryInterface value)
+            => new() { Num = value.Num, String = value.String, DateTimeOffset = value.DateTimeOffset };
+
+        public void Populate(in MyForeignLibraryTypeSurrogate surrogate, MyForeignLibraryInterface value)
         {
             value.Num = surrogate.Num;
             value.String = surrogate.String;


### PR DESCRIPTION
The failures originating from the `InterfaceBasedConverterCodecTests` in this PR all fail with a `ReferenceNotFoundException`.